### PR TITLE
added check for http 0.9 protocol

### DIFF
--- a/src/ngx_http_headers_more_headers_in.c
+++ b/src/ngx_http_headers_more_headers_in.c
@@ -178,6 +178,10 @@ ngx_http_set_header_helper(ngx_http_request_t *r,
 
     dd_enter();
 
+    if (r->http_version < NGX_HTTP_VERSION_10) {
+        return NGX_OK;
+    } 
+
 retry:
     part = &r->headers_in.headers.part;
     h = part->elts;


### PR DESCRIPTION
对于http 0.9协议访问，在ngx_http_process_request_line函数中，并没有调用ngx_list_init来初始化r->headers_in.headers，导致ngx_http_set_header_helper函数在调用ngx_list_push时发生空指针段错误。

利用telnet来构造0.9协议的访问，可以100%重现此问题

代码修改仅供参考
