### PR TITLE
Dynamic Module Support #43

### DIFF
--- a/config
+++ b/config
@@ -1,5 +1,15 @@
 ngx_addon_name=ngx_http_headers_more_filter_module
-HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_headers_more_filter_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/src/ngx_http_headers_more_filter_module.c $ngx_addon_dir/src/ngx_http_headers_more_headers_out.c $ngx_addon_dir/src/ngx_http_headers_more_headers_in.c $ngx_addon_dir/src/ngx_http_headers_more_util.c"
-NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/src/ddebug.h $ngx_addon_dir/src/ngx_http_headers_more_filter_module.h $ngx_addon_dir/src/ngx_http_headers_more_headers_in.h $ngx_addon_dir/src/ngx_http_headers_more_headers_out.h $ngx_addon_dir/src/ngx_http_headers_more_headers_in.h $ngx_addon_dir/src/ngx_http_headers_more_util.h"
 
+if test -n "$ngx_module_link"; then
+    ngx_module_type=HTTP
+    ngx_module_name=ngx_http_headers_more_filter_module
+    ngx_module_incs=
+    ngx_module_deps=
+    ngx_module_srcs="$ngx_addon_dir/src/ngx_http_headers_more_filter_module.c $ngx_addon_dir/src/ngx_http_headers_more_headers_out.c $ngx_addon_dir/src/ngx_http_headers_more_headers_in.c $ngx_addon_dir/src/ngx_http_headers_more_util.c"
+    ngx_module_libs="$ngx_addon_dir/src/ddebug.h $ngx_addon_dir/src/ngx_http_headers_more_filter_module.h $ngx_addon_dir/src/ngx_http_headers_more_headers_in.h $ngx_addon_dir/src/ngx_http_headers_more_headers_out.h $ngx_addon_dir/src/ngx_http_headers_more_headers_in.h $ngx_addon_dir/src/ngx_http_headers_more_util.h"
+
+    . auto/module
+else
+    HTTP_MODULES="$HTTP_MODULES ngx_http_headers_more_filter_module"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/src/ngx_http_headers_more_filter_module.c $ngx_addon_dir/src/ngx_http_headers_more_headers_out.c $ngx_addon_dir/src/ngx_http_headers_more_headers_in.c $ngx_addon_dir/src/ngx_http_headers_more_util.c"
+fi

--- a/config
+++ b/config
@@ -4,12 +4,13 @@ if test -n "$ngx_module_link"; then
     ngx_module_type=HTTP
     ngx_module_name=ngx_http_headers_more_filter_module
     ngx_module_incs=
-    ngx_module_deps=
+    ngx_module_deps="$ngx_addon_dir/src/ddebug.h $ngx_addon_dir/src/ngx_http_headers_more_filter_module.h $ngx_addon_dir/src/ngx_http_headers_more_headers_in.h $ngx_addon_dir/src/ngx_http_headers_more_headers_out.h $ngx_addon_dir/src/ngx_http_headers_more_headers_in.h $ngx_addon_dir/src/ngx_http_headers_more_util.h"
     ngx_module_srcs="$ngx_addon_dir/src/ngx_http_headers_more_filter_module.c $ngx_addon_dir/src/ngx_http_headers_more_headers_out.c $ngx_addon_dir/src/ngx_http_headers_more_headers_in.c $ngx_addon_dir/src/ngx_http_headers_more_util.c"
-    ngx_module_libs="$ngx_addon_dir/src/ddebug.h $ngx_addon_dir/src/ngx_http_headers_more_filter_module.h $ngx_addon_dir/src/ngx_http_headers_more_headers_in.h $ngx_addon_dir/src/ngx_http_headers_more_headers_out.h $ngx_addon_dir/src/ngx_http_headers_more_headers_in.h $ngx_addon_dir/src/ngx_http_headers_more_util.h"
+    ngx_module_libs=
 
     . auto/module
 else
-    HTTP_MODULES="$HTTP_MODULES ngx_http_headers_more_filter_module"
-    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/src/ngx_http_headers_more_filter_module.c $ngx_addon_dir/src/ngx_http_headers_more_headers_out.c $ngx_addon_dir/src/ngx_http_headers_more_headers_in.c $ngx_addon_dir/src/ngx_http_headers_more_util.c"
+  HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_headers_more_filter_module"
+  NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/src/ngx_http_headers_more_filter_module.c $ngx_addon_dir/src/ngx_http_headers_more_headers_out.c $ngx_addon_dir/src/ngx_http_headers_more_headers_in.c $ngx_addon_dir/src/ngx_http_headers_more_util.c"
+  NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/src/ddebug.h $ngx_addon_dir/src/ngx_http_headers_more_filter_module.h $ngx_addon_dir/src/ngx_http_headers_more_headers_in.h $ngx_addon_dir/src/ngx_http_headers_more_headers_out.h $ngx_addon_dir/src/ngx_http_headers_more_headers_in.h $ngx_addon_dir/src/ngx_http_headers_more_util.h"
 fi


### PR DESCRIPTION
Changed to config file so it compiles as a Dynamic Module or as a Normal module.

For dynamic module use: --add-dynamic-module=/etc/nginx/modules/headersmore
For normal module use: --add-module=/etc/nginx/modules/headersmore

Both worked fine for me with the below change.

Issue #43