### PR TITLE
Add headers if not set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ nginx
 *.plist
 a.patch
 Makefile
+autoconf.err
+autotest
+objs/*

--- a/README.markdown
+++ b/README.markdown
@@ -273,7 +273,10 @@ Very much like [more_set_headers](#more_set_headers) except that it operates on 
 
 Note that using the `-t` option in this directive means filtering by the `Content-Type` *request* header, rather than the response header.
 
-Behind the scene, use of this directive and its friend [more_clear_input_headers](#more_clear_input_headers) will (lazily) register a `rewrite phase` handler that modifies `r->headers_in` the way you specify. Note that it always run at the *end* of the `rewrite` so that it runs *after* the standard [rewrite module](http://nginx.org/en/docs/http/ngx_http_rewrite_module.html) and works in subrequests as well.
+Behind the scene, use of this directive and its friend [more_clear_input_headers](#more_clear_input_headers) will (lazily)
+register a `rewrite phase` handler that modifies `r->headers_in` the way you specify. Note that it always run at the *end* of
+the `rewrite` phase so that it runs *after* the standard [rewrite module](http://nginx.org/en/docs/http/ngx_http_rewrite_module.html)
+and works in subrequests as well.
 
 If the `-r` option is specified, then the headers will be replaced to the new values *only if* they already exist.
 

--- a/src/ngx_http_headers_more_filter_module.h
+++ b/src/ngx_http_headers_more_filter_module.h
@@ -61,6 +61,7 @@ struct ngx_http_headers_more_header_val_s {
     ngx_http_headers_more_set_header_pt     handler;
     ngx_uint_t                              offset;
     ngx_flag_t                              replace;
+    ngx_flag_t                              ifnotset;
     ngx_flag_t                              wildcard;
 };
 

--- a/src/ngx_http_headers_more_headers_in.c
+++ b/src/ngx_http_headers_more_headers_in.c
@@ -247,11 +247,11 @@ retry:
             && ngx_strncasecmp(h[i].key.data, hv->key.data,
                                h[i].key.len) == 0)
         {
-            if (value->len == 0 || (matched && matched != &h[i])) {
-                if (hv->ifnotset == 1) {
-                    continue; 
-                }
+            if (hv->ifnotset == 1 && hv->replace == 0) {
+                continue;
+            }
                 
+            if (value->len == 0 || (matched && matched != &h[i])) {
                 h[i].hash = 0;
 
                 rc = ngx_http_headers_more_rm_header_helper(
@@ -272,13 +272,11 @@ retry:
 
                 return NGX_ERROR;
             }
-            if (hv->ifnotset == 0) {
-                h[i].value = *value;
+            h[i].value = *value;
 
-                if (output_header) {
-                    *output_header = &h[i];
-                    dd("setting existing builtin input header");
-                }
+            if (output_header) {
+                *output_header = &h[i];
+                dd("setting existing builtin input header");
             }
 
             if (matched == NULL) {
@@ -291,7 +289,7 @@ retry:
         return NGX_OK;
     }
 
-    if (value->len == 0 || hv->replace) {
+    if (value->len == 0 || (hv->replace && hv->ifnotset == 0)) {
         return NGX_OK;
     }
 

--- a/src/ngx_http_headers_more_headers_in.c
+++ b/src/ngx_http_headers_more_headers_in.c
@@ -360,7 +360,7 @@ ngx_http_set_builtin_header(ngx_http_request_t *r,
     }
 
     if (hv->ifnotset) {
-        dd("skip because of it does set");
+        dd("skip because %s does set", hv->key.data);
         return NGX_OK;
     }
     
@@ -755,7 +755,7 @@ ngx_http_set_builtin_multi_header(ngx_http_request_t *r,
 
     if (headers->nelts > 0) {
         if (hv->ifnotset) {
-            dd("skip multi-value headers because of it does set");
+            dd("skip multi-value headers because %s does set", hv->key.data);
             return NGX_OK;  
         }
 

--- a/src/ngx_http_headers_more_headers_in.c
+++ b/src/ngx_http_headers_more_headers_in.c
@@ -268,12 +268,13 @@ retry:
 
                 return NGX_ERROR;
             }
+            if (hv->ifnotset == 0) {
+                h[i].value = *value;
 
-            h[i].value = *value;
-
-            if (output_header) {
-                *output_header = &h[i];
-                dd("setting existing builtin input header");
+                if (output_header) {
+                    *output_header = &h[i];
+                    dd("setting existing builtin input header");
+                }
             }
 
             if (matched == NULL) {

--- a/src/ngx_http_headers_more_headers_in.c
+++ b/src/ngx_http_headers_more_headers_in.c
@@ -247,38 +247,36 @@ retry:
             && ngx_strncasecmp(h[i].key.data, hv->key.data,
                                h[i].key.len) == 0)
         {
-            if (hv->ifnotset == 1 && hv->replace == 0) {
-                continue;
-            }
-                
-            if (value->len == 0 || (matched && matched != &h[i])) {
-                h[i].hash = 0;
+            if ((hv->ifnotset == 1 && hv->replace == 0) == 0) {
+                if (value->len == 0 || (matched && matched != &h[i])) {
+                    h[i].hash = 0;
 
-                rc = ngx_http_headers_more_rm_header_helper(
-                                            &r->headers_in.headers, part, i);
+                    rc = ngx_http_headers_more_rm_header_helper(
+                                                &r->headers_in.headers, part, i);
 
-                ngx_http_headers_more_assert(
-                    !(r->headers_in.headers.part.next == NULL
-                      && r->headers_in.headers.last
-                         != &r->headers_in.headers.part));
+                    ngx_http_headers_more_assert(
+                        !(r->headers_in.headers.part.next == NULL
+                          && r->headers_in.headers.last
+                             != &r->headers_in.headers.part));
 
-                if (rc == NGX_OK) {
-                    if (output_header) {
-                        *output_header = NULL;
+                    if (rc == NGX_OK) {
+                        if (output_header) {
+                            *output_header = NULL;
+                        }
+
+                        goto retry;
                     }
 
-                    goto retry;
+                    return NGX_ERROR;
                 }
+                h[i].value = *value;
 
-                return NGX_ERROR;
+                if (output_header) {
+                    *output_header = &h[i];
+                    dd("setting existing builtin input header");
+                }
             }
-            h[i].value = *value;
-
-            if (output_header) {
-                *output_header = &h[i];
-                dd("setting existing builtin input header");
-            }
-
+                
             if (matched == NULL) {
                 matched = &h[i];
             }

--- a/src/ngx_http_headers_more_headers_in.c
+++ b/src/ngx_http_headers_more_headers_in.c
@@ -248,6 +248,10 @@ retry:
                                h[i].key.len) == 0)
         {
             if (value->len == 0 || (matched && matched != &h[i])) {
+                if (hv->ifnotset == 1) {
+                    continue; 
+                }
+                
                 h[i].hash = 0;
 
                 rc = ngx_http_headers_more_rm_header_helper(

--- a/src/ngx_http_headers_more_headers_out.c
+++ b/src/ngx_http_headers_more_headers_out.c
@@ -225,7 +225,8 @@ ngx_http_set_header_helper(ngx_http_request_t *r,
 matched:
         if (hv->ifnotset) {
             dd("skip because of it does set");
-            return NGX_OK;
+            matched = 1;
+            continue;
         }
 
         if (value->len == 0 || matched) {

--- a/src/ngx_http_headers_more_headers_out.c
+++ b/src/ngx_http_headers_more_headers_out.c
@@ -224,7 +224,7 @@ ngx_http_set_header_helper(ngx_http_request_t *r,
 
 matched:
         if (hv->ifnotset) {
-            dd("skip because of it does set");
+            dd("skip because %s does set", hv->key.data);
             matched = 1;
             continue;
         }
@@ -310,7 +310,7 @@ ngx_http_set_builtin_header(ngx_http_request_t *r,
     }
     
     if (hv->ifnotset) {
-        dd("skip because of it does set");
+        dd("skip because %s does set", hv->key.data);
         return NGX_OK;
     }
 
@@ -355,7 +355,7 @@ ngx_http_set_builtin_multi_header(ngx_http_request_t *r,
 
     if (pa->nelts > 0) {
         if (hv->ifnotset) {
-            dd("skip because of it does set");
+            dd("skip because %s does set", hv->key.data);
             return NGX_OK;
         }
 

--- a/t/input.t
+++ b/t/input.t
@@ -5,7 +5,7 @@ use Test::Nginx::Socket; # 'no_plan';
 
 repeat_each(2);
 
-plan tests => repeat_each() * 136;
+plan tests => repeat_each() * 142;
 
 no_long_string();
 #no_diff;
@@ -1372,4 +1372,22 @@ howdy
 
 --- response_body eval
 ["howdy\n", "howdy\n"]
+
+
+=== TEST 55: test -i -r -t work together
+--- config
+    location /foo {
+        more_set_input_headers -i -r -t 'text/html' 'X-Foo: howdy';
+        content_by_lua '
+            local headers = ngx.req.get_headers()
+            ngx.say(headers["X-Foo"])
+        ';
+    }
+--- request eval
+["GET /foo", "GET /foo", "GET /foo"]
+--- more_headers eval
+["Content-Type: text/html", "", "Content-Type: text/html\nX-Foo: hi\n"]
+
+--- response_body eval
+["howdy\n", "nil\n", "howdy\n"]
 

--- a/t/input.t
+++ b/t/input.t
@@ -5,7 +5,7 @@ use Test::Nginx::Socket; # 'no_plan';
 
 repeat_each(2);
 
-plan tests => repeat_each() * 124;
+plan tests => repeat_each() * 128;
 
 no_long_string();
 #no_diff;
@@ -1289,3 +1289,30 @@ X-Forwarded-For: 8.8.8.8
 Foo: 127.0.0.1
 --- no_error_log
 [error]
+
+
+=== TEST 50: set request header if not set the header with -i option
+--- config
+    location /foo {
+        more_set_input_headers -i 'X-Foo: howdy';
+        echo "input_header: $http_x_foo";
+    }
+--- request
+    GET /foo
+--- response_body
+input_header: howdy
+
+
+=== TEST 51: do not set request header if set the header with -i option
+--- config
+    location /foo {
+        more_set_input_headers -i 'X-Foo: howdy';
+        echo "input_header: $http_x_foo";
+    }
+--- request
+    GET /foo
+--- more_headers
+X-Foo: blah
+
+--- response_body
+input_header: blah

--- a/t/input.t
+++ b/t/input.t
@@ -1307,7 +1307,10 @@ input_header: howdy
 --- config
     location /foo {
         more_set_input_headers -i 'X-Foo: howdy';
-        echo "input_header: $http_x_foo";
+        content_by_lua '
+            local headers = ngx.req.get_headers()
+            ngx.say(headers["X-Foo"])
+        ';
     }
 --- request
     GET /foo
@@ -1315,8 +1318,7 @@ input_header: howdy
 X-Foo: blah
 
 --- response_body
-input_header: blah
-
+blah
 
 === TEST 52: do not remove multi request header if set the header with -i option
 --- config

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -5,7 +5,7 @@ use Test::Nginx::Socket;
 
 repeat_each(2);
 
-plan tests => repeat_each() * 113;
+plan tests => repeat_each() * 119;
 
 #master_on();
 #workers(2);
@@ -565,4 +565,37 @@ hi
 --- response_body
 ok
 --- http09
+
+
+=== TEST 34:  do not set response header if set the header with -i option
+--- config
+    location /foo {
+        more_set_headers -i 'X-Foo: bar';
+        echo hi;
+    }
+--- request
+    GET /foo
+--- response_headers
+X-Foo: bar
+--- response_body
+hi
+
+
+=== TEST 35:  set the response header if set the header with -i option
+--- config
+    location = /backend {
+        add_header X-Foo baz;
+        echo hi;
+    }
+
+    location /foo {
+        more_set_headers -i 'X-Foo: bar';
+        proxy_pass http://127.0.0.1:$server_port/backend;
+    }
+--- request
+    GET /foo
+--- response_headers
+X-Foo: baz
+--- response_body
+hi
 

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -5,7 +5,7 @@ use Test::Nginx::Socket;
 
 repeat_each(2);
 
-plan tests => repeat_each() * 119;
+plan tests => repeat_each() * 124;
 
 #master_on();
 #workers(2);
@@ -599,3 +599,27 @@ X-Foo: baz
 --- response_body
 hi
 
+
+=== TEST 36:  test -t -i work together
+--- config
+    location = /backend {
+        add_header Content-Type text/html;
+        echo hi;
+    }
+
+    location /foo {
+        more_set_headers -t 'text/plain' -i 'X-Foo: bar';
+        proxy_pass http://127.0.0.1:$server_port/backend;
+    }
+    
+    location /bar {
+        more_set_headers -t 'text/html' -i 'X-Foo: bar';
+        proxy_pass http://127.0.0.1:$server_port/backend;
+    }
+    
+--- request eval
+["GET /foo", "GET /bar"]
+--- response_headers eval
+["", "X-Foo: bar"]
+--- response_body eval
+["hi\n", "hi\n"]


### PR DESCRIPTION
Hello.
This PR is about the issue #60 for @SamMousa . It would add header if not present the specified header.
new option (-i) usage as the following:

````bash
 # add input header X-Foo *only* if it `X-Foo` doesnt exist
 more_set_input_headers -i 'X-Foo: howdy';

 # add output header X-Foo *only* if it `X-Foo` doesnt exist
 more_set_headers -i 'X-Foo: howdy';
````

@agentzh please review this PR :grin: