### PR TITLE
Set r->keepalive = 0 in ngx_http_set_connection_header

### DIFF
--- a/src/ngx_http_headers_more_headers_in.c
+++ b/src/ngx_http_headers_more_headers_in.c
@@ -739,6 +739,7 @@ ngx_http_set_connection_header(ngx_http_request_t *r,
     if (ngx_strcasestrn(value->data, "close", 5 - 1)) {
         r->headers_in.connection_type = NGX_HTTP_CONNECTION_CLOSE;
         r->headers_in.keep_alive_n = -1;
+        r->keepalive = 0;
 
     } else if (ngx_strcasestrn(value->data, "keep-alive", 10 - 1)) {
         r->headers_in.connection_type = NGX_HTTP_CONNECTION_KEEP_ALIVE;


### PR DESCRIPTION
HTTP keepalive was effective even with `more_set_input_headers 'Connection: close';`.
`r->keepalive = 0` may be required to close connection.
