### PR TITLE
Remove wildcard length lower limit

### DIFF
--- a/src/ngx_http_headers_more_util.c
+++ b/src/ngx_http_headers_more_util.c
@@ -85,12 +85,6 @@ ngx_http_headers_more_parse_header(ngx_conf_t *cf, ngx_str_t *cmd_name,
     }
 
     hv->wildcard = (key.data[key.len - 1] == '*');
-    if (hv->wildcard && key.len<2){
-        ngx_log_error(NGX_LOG_ERR, cf->log, 0,
-                      "%V: wildcard key too short: %V",
-                      cmd_name, raw_header);
-        return NGX_ERROR;
-    }
 
     hv->hash = ngx_hash_key_lc(key.data, key.len);
     hv->key = key;


### PR DESCRIPTION
This limitation seems arbitrary and I didn't find any discussion preceding it. So, I removed it. Verified with nginx 1.20.2.