### PR TITLE
bugfix: fix build error with nginx >= 1.23.0

### DIFF
--- a/src/ngx_http_headers_more_headers_in.c
+++ b/src/ngx_http_headers_more_headers_in.c
@@ -158,9 +158,15 @@ static ngx_http_headers_more_set_header_t ngx_http_headers_more_set_handlers[]
                  ngx_http_set_builtin_header },
 #endif
 
+#if defined(nginx_version) && nginx_version >= 1023000
+    { ngx_string("Cookie"),
+                 offsetof(ngx_http_headers_in_t, cookie),
+                 ngx_http_set_builtin_multi_header },
+#else
     { ngx_string("Cookie"),
                  offsetof(ngx_http_headers_in_t, cookies),
                  ngx_http_set_builtin_multi_header },
+#endif
 
     { ngx_null_string, 0, ngx_http_set_header }
 };


### PR DESCRIPTION
This will fix #132 .

`cookies` field name just renamed to `cookie`, according to https://github.com/nginx/nginx/commit/3aef1d693f3cc431563a7e6a6aba6a34e5290f03 .