### PR TITLE
Update handling of multiple headers changed in nginx 1.23.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,3 +52,4 @@ script:
   - export NGX_BUILD_CC=$CC
   - sh util/build.sh $NGINX_VERSION > build.log 2>&1 || (cat build.log && exit 1)
   - prove -I. -r t
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
   matrix:
     - NGINX_VERSION=1.19.3
     - NGINX_VERSION=1.19.9
+    - NGINX_VERSION=1.23.0
 
 before_install:
   - sudo apt-get update -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 
 install:
   - git clone https://github.com/openresty/echo-nginx-module.git ../echo-nginx-module
-  - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
+  - git clone -b update_for_nginx_1_23_0 https://github.com/hnakamur/lua-nginx-module.git ../lua-nginx-module
   - git clone https://github.com/openresty/lua-resty-core.git ../lua-resty-core
   - git clone https://github.com/openresty/lua-resty-lrucache.git ../lua-resty-lrucache
   - git clone https://github.com/openresty/nginx-eval-module.git ../eval-nginx-module

--- a/src/ngx_http_headers_more_headers_in.c
+++ b/src/ngx_http_headers_more_headers_in.c
@@ -793,9 +793,11 @@ ngx_http_set_builtin_multi_header(ngx_http_request_t *r,
     if (*headers) {
         for (ph = headers; *ph; ph = &(*ph)->next) { /* void */ }
         *ph = h;
+
     } else {
         *headers = h;
     }
+
     h->next = NULL;
 
     return NGX_OK;

--- a/src/ngx_http_headers_more_headers_in.c
+++ b/src/ngx_http_headers_more_headers_in.c
@@ -758,6 +758,48 @@ static ngx_int_t
 ngx_http_set_builtin_multi_header(ngx_http_request_t *r,
     ngx_http_headers_more_header_val_t *hv, ngx_str_t *value)
 {
+#if defined(nginx_version) && nginx_version >= 1023000
+    ngx_table_elt_t  **headers, **ph, *h;
+    int                nelts;
+
+    if (r->headers_out.status == 400 || r->headers_in.headers.last == NULL) {
+        /* must be a 400 Bad Request */
+        return NGX_OK;
+    }
+
+    headers = (ngx_table_elt_t **) ((char *) &r->headers_in + hv->offset);
+
+    if (*headers) {
+        nelts = 0;
+        for (h = *headers; h; h = h->next) {
+            nelts++;
+        }
+
+        *headers = NULL;
+
+        dd("clear multi-value headers: %d", nelts);
+    }
+
+    if (ngx_http_set_header_helper(r, hv, value, &h) == NGX_ERROR) {
+        return NGX_ERROR;
+    }
+
+    if (value->len == 0) {
+        return NGX_OK;
+    }
+
+    dd("new multi-value header: %p", h);
+
+    if (*headers) {
+        for (ph = headers; *ph; ph = &(*ph)->next) { /* void */ }
+        *ph = h;
+    } else {
+        *headers = h;
+    }
+    h->next = NULL;
+
+    return NGX_OK;
+#else
     ngx_array_t       *headers;
     ngx_table_elt_t  **v, *h;
 
@@ -810,6 +852,7 @@ ngx_http_set_builtin_multi_header(ngx_http_request_t *r,
 
     *v = h;
     return NGX_OK;
+#endif
 }
 
 

--- a/src/ngx_http_headers_more_headers_out.c
+++ b/src/ngx_http_headers_more_headers_out.c
@@ -327,6 +327,46 @@ static ngx_int_t
 ngx_http_set_builtin_multi_header(ngx_http_request_t *r,
     ngx_http_headers_more_header_val_t *hv, ngx_str_t *value)
 {
+#if defined(nginx_version) && nginx_version >= 1023000
+    ngx_table_elt_t  **headers, *h, *ho, **ph;
+
+    headers = (ngx_table_elt_t **) ((char *) &r->headers_out + hv->offset);
+
+    if (*headers) {
+        for (h = (*headers)->next; h; h = h->next) {
+            h->hash = 0;
+            h->value.len = 0;
+        }
+
+        h = *headers;
+
+        h->value = *value;
+
+        if (value->len == 0) {
+            h->hash = 0;
+
+        } else {
+            h->hash = hv->hash;
+        }
+
+        return NGX_OK;
+    }
+
+    for (ph = headers; *ph; ph = &(*ph)->next) { /* void */ }
+
+    ho = ngx_list_push(&r->headers_out.headers);
+    if (ho == NULL) {
+        return NGX_ERROR;
+    }
+
+    ho->value = *value;
+    ho->hash = hv->hash;
+    ngx_str_set(&ho->key, "Cache-Control");
+    ho->next = NULL;
+    *ph = ho;
+
+    return NGX_OK;
+#else
     ngx_array_t      *pa;
     ngx_table_elt_t  *ho, **ph;
     ngx_uint_t        i;
@@ -378,6 +418,7 @@ ngx_http_set_builtin_multi_header(ngx_http_request_t *r,
     *ph = ho;
 
     return NGX_OK;
+#endif
 }
 
 


### PR DESCRIPTION
This fixes [headers-more-nginx-module not compatible with nginx 1.23.0 · Issue #132 · openresty/headers-more-nginx-module](https://github.com/openresty/headers-more-nginx-module/issues/132).