### PR TITLE
bugfix: fixed an unused variable on non-debug builds

### DIFF
--- a/src/ngx_http_headers_more_headers_in.c
+++ b/src/ngx_http_headers_more_headers_in.c
@@ -763,7 +763,9 @@ ngx_http_set_builtin_multi_header(ngx_http_request_t *r,
 {
 #if defined(nginx_version) && nginx_version >= 1023000
     ngx_table_elt_t  **headers, **ph, *h;
+#if (DDEBUG)
     int                nelts;
+#endif
 
     if (r->headers_out.status == 400 || r->headers_in.headers.last == NULL) {
         /* must be a 400 Bad Request */
@@ -773,14 +775,16 @@ ngx_http_set_builtin_multi_header(ngx_http_request_t *r,
     headers = (ngx_table_elt_t **) ((char *) &r->headers_in + hv->offset);
 
     if (*headers) {
+#if (DDEBUG)
         nelts = 0;
         for (h = *headers; h; h = h->next) {
             nelts++;
         }
 
-        *headers = NULL;
-
         dd("clear multi-value headers: %d", nelts);
+#endif
+        
+        *headers = NULL;
     }
 
     if (ngx_http_set_header_helper(r, hv, value, &h) == NGX_ERROR) {


### PR DESCRIPTION
```
[...]/headers-more-nginx-module/src/ngx_http_headers_more_headers_in.c:766:24: error: variable 'nelts' set but not used [-Werror,-Wunused-but-set-variable]
    int                nelts;
                       ^
1 error generated.
```