### PR TITLE
feature: add append mode for more_set_headers(so far just for Set-Cookie field)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -134,7 +134,7 @@ Directives
 
 more_set_headers
 ----------------
-**syntax:** *more_set_headers [-t &lt;content-type list&gt;]... [-s &lt;status-code list&gt;]... &lt;new-header&gt;...*
+**syntax:** *more_set_headers [-a] [-t &lt;content-type list&gt;]... [-s &lt;status-code list&gt;]... &lt;new-header&gt;...*
 
 **default:** *no*
 
@@ -143,6 +143,8 @@ more_set_headers
 **phase:** *output-header-filter*
 
 Replaces (if any) or adds (if not any) the specified output headers when the response status code matches the codes specified by the `-s` option *AND* the response content type matches the types specified by the `-t` option.
+
+If the `-a` option is specified, Set-Cookie fields can be appended directly without clearing the old fields. So far the `-a` option only affects the Set-Cookie field, it does not change the behavior when setting other fields.
 
 If either `-s` or `-t` is not specified or has an empty list value, then no match is required. Therefore, the following directive set the `Server` output header to the custom value for *any* status code and *any* content type:
 

--- a/README.markdown
+++ b/README.markdown
@@ -134,7 +134,7 @@ Directives
 
 more_set_headers
 ----------------
-**syntax:** *more_set_headers [-a] [-t &lt;content-type list&gt;]... [-s &lt;status-code list&gt;]... &lt;new-header&gt;...*
+**syntax:** *more_set_headers [-t &lt;content-type list&gt;]... [-s &lt;status-code list&gt;]... [-a] &lt;new-header&gt;...*
 
 **default:** *no*
 

--- a/src/ngx_http_headers_more_filter_module.h
+++ b/src/ngx_http_headers_more_filter_module.h
@@ -60,8 +60,9 @@ struct ngx_http_headers_more_header_val_s {
     ngx_str_t                               key;
     ngx_http_headers_more_set_header_pt     handler;
     ngx_uint_t                              offset;
-    ngx_flag_t                              replace;
-    ngx_flag_t                              wildcard;
+    unsigned                                replace:1;
+    unsigned                                wildcard:1;
+    unsigned                                append:1;
 };
 
 

--- a/src/ngx_http_headers_more_headers_out.c
+++ b/src/ngx_http_headers_more_headers_out.c
@@ -184,6 +184,10 @@ ngx_http_set_header_helper(ngx_http_request_t *r,
     }
 #endif
 
+    if (hv->append) {
+        goto append;
+    }
+
     part = &r->headers_out.headers.part;
     h = part->elts;
 
@@ -254,6 +258,8 @@ matched:
     /* XXX we still need to create header slot even if the value
      * is empty because some builtin headers like Last-Modified
      * relies on this to get cleared */
+
+append:
 
     h = ngx_list_push(&r->headers_out.headers);
     if (h == NULL) {
@@ -606,14 +612,16 @@ static char *
 ngx_http_headers_more_parse_directive(ngx_conf_t *cf, ngx_command_t *ngx_cmd,
     void *conf, ngx_http_headers_more_opcode_t opcode)
 {
-    ngx_http_headers_more_loc_conf_t  *hlcf = conf;
+    ngx_http_headers_more_loc_conf_t   *hlcf = conf;
 
-    ngx_uint_t                         i;
-    ngx_http_headers_more_cmd_t       *cmd;
-    ngx_str_t                         *arg;
-    ngx_flag_t                         ignore_next_arg;
-    ngx_str_t                         *cmd_name;
-    ngx_int_t                          rc;
+    ngx_uint_t                          i;
+    ngx_http_headers_more_cmd_t        *cmd;
+    ngx_str_t                          *arg;
+    ngx_flag_t                          ignore_next_arg;
+    ngx_str_t                          *cmd_name;
+    ngx_int_t                           rc;
+    ngx_flag_t                          append = 0;
+    ngx_http_headers_more_header_val_t *h;
 
     ngx_http_headers_more_main_conf_t  *hmcf;
 
@@ -721,6 +729,11 @@ ngx_http_headers_more_parse_directive(ngx_conf_t *cf, ngx_command_t *ngx_cmd,
                 ignore_next_arg = 1;
 
                 continue;
+            } else if (arg[i].data[1] == 'a') {
+
+                dd("Found append flag");
+                append = 1;
+                continue;
             }
         }
 
@@ -736,6 +749,16 @@ ngx_http_headers_more_parse_directive(ngx_conf_t *cf, ngx_command_t *ngx_cmd,
 
     if (cmd->headers->nelts == 0) {
         cmd->headers = NULL;
+    } else {
+        h = cmd->headers->elts;
+        for (i = 0; i < cmd->headers->nelts; i++) {
+            if (ngx_strncasecmp(h[i].key.data, (u_char*) "Set-Cookie",
+                                 h[i].key.len) == 0)
+            {
+
+                h[i].append = append;
+            }
+        }
     }
 
     if (cmd->types->nelts == 0) {

--- a/src/ngx_http_headers_more_headers_out.c
+++ b/src/ngx_http_headers_more_headers_out.c
@@ -729,6 +729,7 @@ ngx_http_headers_more_parse_directive(ngx_conf_t *cf, ngx_command_t *ngx_cmd,
                 ignore_next_arg = 1;
 
                 continue;
+
             } else if (arg[i].data[1] == 'a') {
 
                 dd("Found append flag");
@@ -749,11 +750,13 @@ ngx_http_headers_more_parse_directive(ngx_conf_t *cf, ngx_command_t *ngx_cmd,
 
     if (cmd->headers->nelts == 0) {
         cmd->headers = NULL;
+
     } else {
         h = cmd->headers->elts;
         for (i = 0; i < cmd->headers->nelts; i++) {
-            if (ngx_strncasecmp(h[i].key.data, (u_char*) "Set-Cookie",
-                                 h[i].key.len) == 0)
+
+            if (ngx_strncasecmp(h[i].key.data, (u_char *) "Set-Cookie",
+                                h[i].key.len) == 0)
             {
 
                 h[i].append = append;

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -592,7 +592,8 @@ ok
     }
 --- request
     GET /cookie
---- raw_response_headers_like: Set-Cookie: name=lynch\r\n
+--- raw_response_headers_like eval
+"Set-Cookie: name=lynch\r\nSet-Cookie: born=1981\r\n"
 --- response_body
 ok
 
@@ -610,5 +611,3 @@ ok
 --- raw_response_headers_unlike: X-Ua-Compatible: IE=Edge\r\n
 --- response_body
 ok
-
-

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -5,7 +5,7 @@ use Test::Nginx::Socket;
 
 repeat_each(2);
 
-plan tests => repeat_each() * 113;
+plan tests => repeat_each() * 122;
 
 #master_on();
 #workers(2);
@@ -565,3 +565,50 @@ hi
 --- response_body
 ok
 --- http09
+
+
+
+=== TEST 34: use the -a option to append the cookie field
+--- config
+    location /cookie {
+        more_set_headers -a 'Set-Cookie: name=lynch';
+        echo ok;
+    }
+--- request
+    GET /cookie
+--- response_headers
+Set-Cookie: name=lynch
+--- response_body
+ok
+
+
+
+=== TEST 35: the original Set-Cookie fields will not be overwritten, when using the -a option
+--- config
+    location /cookie {
+        more_set_headers 'Set-Cookie: name=lynch';
+        more_set_headers -a 'Set-Cookie: born=1981';
+        echo ok;
+    }
+--- request
+    GET /cookie
+--- raw_response_headers_like: Set-Cookie: name=lynch\r\n
+--- response_body
+ok
+
+
+
+=== TEST 36: the -a option does nothing when the field is not Set-Cookie
+--- config
+    location /cookie {
+        more_set_headers "X-Ua-Compatible: IE=Edge";
+        more_set_headers -a "X-Ua-Compatible: chrome=1";
+        echo ok;
+    }
+--- request
+    GET /cookie
+--- raw_response_headers_unlike: X-Ua-Compatible: IE=Edge\r\n
+--- response_body
+ok
+
+


### PR DESCRIPTION
allow append Set-Cookie fields when use -a option
fix this issue, Repeated headers are occluded incorrectly #141
