### PR TITLE
bugfix: fixed uninitialised field 'h[i]->append'.

### DIFF
--- a/src/ngx_http_headers_more_headers_out.c
+++ b/src/ngx_http_headers_more_headers_out.c
@@ -767,6 +767,7 @@ ngx_http_headers_more_parse_directive(ngx_conf_t *cf, ngx_command_t *ngx_cmd,
 
         h = cmd->headers->elts;
         for (i = 0; i < cmd->headers->nelts; i++) {
+            h[i].append = 0;
 
             handlers = ngx_http_headers_more_set_handlers;
 


### PR DESCRIPTION
==934== Conditional jump or move depends on uninitialised value(s)
==934== at 0x4E1823: ngx_http_set_header_helper (ngx_http_headers_more_headers_out.c:187)
==934== by 0x4E1B77: ngx_http_set_builtin_header (ngx_http_headers_more_headers_out.c:310)
==934== by 0x4E1D55: ngx_http_headers_more_exec_cmd (ngx_http_headers_more_headers_out.c:143)
==934== by 0x4E11D7: ngx_http_headers_more_filter (ngx_http_headers_more_filter_module.c:134)
==934== by 0x4E3CD0: ngx_http_iconv_header_filter (ngx_http_iconv_module.c:155)
==934== by 0x479989: ngx_http_not_modified_header_filter (ngx_http_not_modified_filter_module.c:108)
==934== by 0x44BF7E: ngx_http_send_header (ngx_http_core_module.c:1859)
==934== by 0x499F7D: ngx_http_echo_send_header_if_needed (ngx_http_echo_util.c:163)
==934== by 0x499F9C: ngx_http_echo_send_chain_link (ngx_http_echo_util.c:113)
==934== by 0x49BB81: ngx_http_echo_exec_echo (ngx_http_echo_echo.c:224)
==934== by 0x49A5ED: ngx_http_echo_run_cmds (ngx_http_echo_handler.c:232)
==934== by 0x49A949: ngx_http_echo_handler (ngx_http_echo_handler.c:111)
==934== by 0x44C3EE: ngx_http_core_content_phase (ngx_http_core_module.c:1271)
==934== by 0x446DF2: ngx_http_core_run_phases (ngx_http_core_module.c:885)
==934== by 0x446EFD: ngx_http_handler (ngx_http_core_module.c:868)
==934== by 0x44F36D: ngx_http_process_request (ngx_http_request.c:2127)
==934== by 0x45245F: ngx_http_process_request_line (ngx_http_request.c:1180)
==934== by 0x452F20: ngx_http_wait_request_handler (ngx_http_request.c:523)
==934== by 0x442E17: ngx_epoll_process_events (ngx_epoll_module.c:901)
==934== by 0x437F11: ngx_process_events_and_timers (ngx_event.c:258)
==934== by 0x441DD7: ngx_single_process_cycle (ngx_process_cycle.c:323)
==934== by 0x416DC8: main (nginx.c:384)
==934==